### PR TITLE
Generate relative url (without host) instead absolute url

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -255,7 +255,7 @@ This code manage the many-to-[one|many] association field popup
 
                         // reload the form element
                         jQuery('#field_widget_{{ id }}').closest('form').ajaxSubmit({
-                            url: '{{ url('sonata_admin_retrieve_form_element', {
+                            url: '{{ path('sonata_admin_retrieve_form_element', {
                                 'elementId': id,
                                 'subclass':  sonata_admin.admin.getActiveSubclassCode(),
                                 'objectId':  sonata_admin.admin.root.id(sonata_admin.admin.root.subject),
@@ -396,7 +396,7 @@ This code manage the many-to-[one|many] association field popup
             jQuery('#field_widget_{{ id }}').html("<span><img src=\"{{ asset('bundles/sonataadmin/ajax-loader.gif') }}\" style=\"vertical-align: middle; margin-right: 10px\"/>{{ 'loading_information'|trans([], 'SonataAdminBundle') }}</span>");
             jQuery.ajax({
                 type: 'GET',
-                url: '{{ url('sonata_admin_short_object_information', {
+                url: '{{ path('sonata_admin_short_object_information', {
                     'objectId': 'OBJECT_ID',
                     'uniqid': associationadmin.uniqid,
                     'code': associationadmin.code,

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -55,7 +55,7 @@ file that was distributed with this source code.
         <span id="field_actions_{{ id }}" class="field-actions">
             <span id="field_widget_{{ id }}" class="field-short-description">
                 {% if sonata_admin.field_description.associationadmin.id(sonata_admin.value) %}
-                    {% render url('sonata_admin_short_object_information', {
+                    {% render path('sonata_admin_short_object_information', {
                         'code':     sonata_admin.field_description.associationadmin.code,
                         'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),
                         'uniqid':   sonata_admin.field_description.associationadmin.uniqid,


### PR DESCRIPTION
Replaced "url" with "path" in twig templates.

Problem was that in development environment URLs generated by url
function were pointing to production instance when site entity property
"host" was set to production host name. This was causing confusion when
using certain links on different than production environment.
